### PR TITLE
Handled unknown response objects that contain json body

### DIFF
--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -107,10 +107,15 @@ class Debugger
     protected function updateResponse(Request $request, Response $response)
     {
         if ($this->needToUpdateResponse($response)) {
-            $data = $response->getData(true) ?: [];
+            $data = $this->getResponseData($response);
+
+            if ($data === false) {
+                return;
+            }
+
             $data[$this->responseKey] = $this->storage->getData();
 
-            $response->setData($data);
+            $this->setResponseData($response, $data);
         }
     }
 
@@ -122,7 +127,47 @@ class Debugger
      */
     protected function needToUpdateResponse(Response $response)
     {
-        return $response instanceof JsonResponse && ! $this->storage->isEmpty();
+        $isJsonResponse = $response instanceof JsonResponse || $response->headers->contains('content-type',
+                'application/json');
+
+        return $isJsonResponse && !$this->storage->isEmpty();
+    }
+
+    /**
+     * Fetches the contents of the response and parses them to an assoc array
+     *
+     * @param Response $response
+     * @return array|bool
+     */
+    protected function getResponseData(Response $response)
+    {
+        if ($response instanceof JsonResponse) {
+            /** @var $response JsonResponse */
+            return $response->getData(true) ?: [];
+        }
+
+        $content = $response->getContent();
+
+        return json_decode($content, true) ?: false;
+    }
+
+    /**
+     * Updates the response content
+     *
+     * @param Response $response
+     * @param array    $data
+     * @return JsonResponse|Response
+     */
+    protected function setResponseData(Response $response, array $data)
+    {
+        if ($response instanceof JsonResponse) {
+            /** @var $response JsonResponse */
+            return $response->setData($data);
+        }
+
+        $content = json_encode($data, JsonResponse::DEFAULT_ENCODING_OPTIONS);
+
+        return $response->setContent($content);
     }
 
     /**


### PR DESCRIPTION
[Dingo](https://github.com/dingo/api) uses it's custom Response object that, unfortunately, does not extend `JsonResponse`

The changes that I've made are not limited to Dingo responses, in any `Response` object has a json content-type (we assume that has a json body) we'll handle the debug workflow as intended.

Hope that can help someone else 😄 