### PR TITLE
Enable/disable api debugger only

### DIFF
--- a/config/api-debugger.php
+++ b/config/api-debugger.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'enabled' => (bool) env('API_DEBUGGER_ENABLED', env('APP_DEBUG', false)),
     /**
      * Specify what data to collect.
      */

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,4 +19,7 @@
             <directory suffix=".php">./src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <env name="API_DEBUGGER_ENABLED" value="true"/>
+    </php>
 </phpunit>

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -22,7 +22,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         // Register collections only for debug environment.
         $config = $this->app['config'];
-        if ($config['app.debug']) {
+        if ($config['api-debugger.enabled']) {
             $this->registerCollections($config['api-debugger.collections']);
         }
     }


### PR DESCRIPTION
This PR makes it possible to enable or disable the api debugger, without changing the `APP_DEBUG` env variable. It fallbacks on the `APP_DEBUG` var when the new env variable isn't set. 

After making this PR i saw that there already was a PR with the same functionality. Ofcourse credits to [Jezzdk]( https://github.com/jezzdk)  ([PR](https://github.com/mlanin/laravel-api-debugger/pull/13))