### PR TITLE
Check response data type before appending

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,14 @@
         }
     ],
     "require": {
+        "ext-sqlite3": "*",
+        "ext-pdo_sqlite": "*",
         "php": ">=5.6.0",
-        "illuminate/support": ">=5.4.0"
+        "illuminate/support": "5.4.*"
     },
     "require-dev": {
-        "orchestra/testbench": ">=3.4.0",
-        "phpunit/phpunit": ">=5.7",
+        "orchestra/testbench": "3.4.*",
+        "phpunit/phpunit": "^5.7.0",
         "mockery/mockery": "0.9.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "ext-sqlite3": "*",
-        "ext-pdo_sqlite": "*",
         "php": ">=5.6.0",
         "illuminate/support": "5.4.*"
     },
     "require-dev": {
+        "ext-sqlite3": "*",
+        "ext-pdo_sqlite": "*",
         "orchestra/testbench": "3.4.*",
         "phpunit/phpunit": "^5.7.0",
         "mockery/mockery": "0.9.*"

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,12 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "illuminate/support": "5.4.*"
+        "illuminate/support": ">=5.4.0"
     },
     "require-dev": {
-        "ext-sqlite3": "*",
         "ext-pdo_sqlite": "*",
-        "orchestra/testbench": "3.4.*",
-        "phpunit/phpunit": "^5.7.0",
+        "orchestra/testbench": ">=3.4.0",
+        "phpunit/phpunit": ">=5.7.0",
         "mockery/mockery": "0.9.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
         "ext-sqlite3": "*",
         "ext-pdo_sqlite": "*",
         "php": ">=5.6.0",
-        "illuminate/support": "5.4.*"
+      "illuminate/support": ">=5.4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "3.4.*",
-        "phpunit/phpunit": "^5.7.0",
+      "orchestra/testbench": ">=3.4.0",
+      "phpunit/phpunit": ">=5.7.0",
         "mockery/mockery": "0.9.*"
     },
     "autoload": {

--- a/src/Collections/QueriesCollection.php
+++ b/src/Collections/QueriesCollection.php
@@ -50,6 +50,7 @@ class QueriesCollection implements Collection
         return [
             'total' => count($this->queries),
             'items' => $this->queries,
+            'time' => collect($this->queries)->sum('time')
         ];
     }
 

--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -111,7 +111,7 @@ class Debugger
         if ($this->needToUpdateResponse($response)) {
             $data = $this->getResponseData($response);
 
-            if ($data === false) {
+            if ( $data === false || !is_array($data) || !is_object($data) ) {
                 return;
             }
 

--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -142,7 +142,7 @@ class Debugger
         if ($this->needToUpdateResponse($response)) {
             $data = $this->getResponseData($response);
 
-            if ( $data === false || !is_array($data) ) {
+            if ( !is_array($data) && !is_object($data) ) {
                 return;
             }
 

--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -14,6 +14,11 @@ use Symfony\Component\HttpFoundation\Response;
 class Debugger
 {
     /**
+     * @var bool
+     */
+    protected $disabled = false;
+
+    /**
      * @var string
      */
     protected $responseKey = 'debug';
@@ -69,6 +74,9 @@ class Debugger
      */
     public function startProfiling($name)
     {
+        if ($this->isDisabled()) {
+            return;
+        }
         $this->event->dispatch(new StartProfiling($name));
     }
 
@@ -79,6 +87,9 @@ class Debugger
      */
     public function stopProfiling($name)
     {
+        if ($this->isDisabled()) {
+            return;
+        }
         $this->event->dispatch(new StopProfiling($name));
     }
 
@@ -96,6 +107,26 @@ class Debugger
         $this->stopProfiling($name);
 
         return $return;
+    }
+
+    /**
+     * Turn the debugger on/off
+     *
+     * @param  bool  $val
+     */
+    public function disable($val = true)
+    {
+        $this->disabled = $val;
+    }
+
+    /**
+     * Is the debugger disabled?
+     *
+     * @return bool
+     */
+    protected function isDisabled()
+    {
+        return $this->disabled;
     }
 
     /**
@@ -132,7 +163,7 @@ class Debugger
         $isJsonResponse = $response instanceof JsonResponse || $response->headers->contains('content-type',
                 'application/json');
 
-        return $isJsonResponse && !$this->storage->isEmpty();
+        return ! $this->isDisabled() && $isJsonResponse && ! $this->storage->isEmpty();
     }
 
     /**

--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -111,7 +111,7 @@ class Debugger
         if ($this->needToUpdateResponse($response)) {
             $data = $this->getResponseData($response);
 
-            if ( $data === false || !is_array($data) || !is_object($data) ) {
+            if ( $data === false || !is_array($data) ) {
                 return;
             }
 

--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -142,7 +142,7 @@ class Debugger
         if ($this->needToUpdateResponse($response)) {
             $data = $this->getResponseData($response);
 
-            if ( !is_array($data) && !is_object($data) ) {
+            if (! is_object($data)) {
                 return;
             }
 

--- a/tests/DebuggerTest.php
+++ b/tests/DebuggerTest.php
@@ -231,7 +231,7 @@ class DebuggerTest extends TestCase
     }
 
     /** @test */
-    public function is_does_not_add_debug_if_response_is_integer()
+    public function it_does_not_add_debug_if_response_is_integer()
     {
 	    $this->app['router']->get('foo', function () {
 		    lad('test if integer');
@@ -241,7 +241,7 @@ class DebuggerTest extends TestCase
 
 	    $this->json('get', '/foo')
 	         ->assertStatus(200)
-	         ->assertJsonMissingExact([
+	         ->assertJsonMissing([
 	         	'debug' => [
 	         		'dump' => [
 	         			'test if integer',

--- a/tests/DebuggerTest.php
+++ b/tests/DebuggerTest.php
@@ -199,4 +199,23 @@ class DebuggerTest extends TestCase
                 ],
             ]);
     }
+
+    public function is_does_not_add_debug_if_response_is_integer()
+    {
+	    $this->app['router']->get('foo', function () {
+		    lad('test if integer');
+
+		    return response()->json(1234);
+	    });
+
+	    $this->json('get', '/foo')
+	         ->assertStatus(200)
+	         ->assertJsonMissingExact([
+	         	'debug' => [
+	         		'dump' => [
+	         			'test if integer',
+		            ]
+	            ]
+	         ]);
+    }
 }

--- a/tests/DebuggerTest.php
+++ b/tests/DebuggerTest.php
@@ -200,6 +200,7 @@ class DebuggerTest extends TestCase
             ]);
     }
 
+    /** @test */
     public function is_does_not_add_debug_if_response_is_integer()
     {
 	    $this->app['router']->get('foo', function () {


### PR DESCRIPTION
My implementation of responses sometimes has integers as the response content. This will of course produce an error trying to access an index of an integer like an array.

I have added a check to make sure the response data is an array before trying to attach the debug property to the response.

Also: I have added a small convenience for seeing the total time of all the queries in the query collection.