### PR TITLE
feat: add config option to change response key

### DIFF
--- a/config/api-debugger.php
+++ b/config/api-debugger.php
@@ -18,4 +18,6 @@ return [
         // Memory usage.
         \Lanin\Laravel\ApiDebugger\Collections\MemoryCollection::class,
     ],
+
+    'response_key' => env('API_DEBUGGER_KEY', 'debug')
 ];

--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -178,6 +178,16 @@ class Debugger
     }
 
     /**
+     * Get the current response key
+     *
+     * @return string
+     */
+    public function getResponseKey()
+    {
+        return $this->responseKey;
+    }
+
+    /**
      * Set response attribute key name.
      *
      * @param $key

--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -16,7 +16,7 @@ class Debugger
     /**
      * @var string
      */
-    protected $responseKey = 'debug';
+    protected $responseKey;
 
     /**
      * @var Storage
@@ -38,6 +38,8 @@ class Debugger
     {
         $this->storage = $storage;
         $this->event = $event;
+
+        $this->responseKey = config('api-debugger.response_key', 'debug');
 
         $this->event->listen(RequestHandled::class, function (RequestHandled $event) {
             $this->updateResponse($event->request, $event->response);

--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -16,7 +16,12 @@ class Debugger
     /**
      * @var string
      */
-    protected $responseKey;
+    const DEFAULT_RESPONSE_KEY = 'debug';
+
+    /**
+     * @var string
+     */
+    protected $responseKey = self::DEFAULT_RESPONSE_KEY;
 
     /**
      * @var Storage
@@ -38,8 +43,6 @@ class Debugger
     {
         $this->storage = $storage;
         $this->event = $event;
-
-        $this->responseKey = config('api-debugger.response_key', 'debug');
 
         $this->event->listen(RequestHandled::class, function (RequestHandled $event) {
             $this->updateResponse($event->request, $event->response);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -24,6 +24,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $config = $this->app['config'];
         if ($config['api-debugger.enabled']) {
             $this->registerCollections($config['api-debugger.collections']);
+
+            $this->setResponseKey($config['api-debugger.response_key']);
         }
     }
 
@@ -60,6 +62,21 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         foreach ($collections as $collection) {
             $debugger->populateWith($this->app->make($collection));
+        }
+    }
+
+    /**
+     * Set the response key for the debug object
+     * (default: debug)
+     *
+     * @param string key
+     */
+    protected function setResponseKey($key)
+    {
+        $debugger = $this->app->make(Debugger::class);
+
+        if($key !== Debugger::DEFAULT_RESPONSE_KEY){
+            $debugger->setResponseKey($key);
         }
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -75,7 +75,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $debugger = $this->app->make(Debugger::class);
 
-        if($key !== Debugger::DEFAULT_RESPONSE_KEY){
+        if($key && $key !== Debugger::DEFAULT_RESPONSE_KEY){
             $debugger->setResponseKey($key);
         }
     }

--- a/tests/DebuggerTest.php
+++ b/tests/DebuggerTest.php
@@ -4,6 +4,7 @@ namespace Lanin\Laravel\ApiDebugger\Tests;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Cache;
+use Lanin\Laravel\ApiDebugger\Debugger;
 
 class DebuggerTest extends TestCase
 {
@@ -228,5 +229,20 @@ class DebuggerTest extends TestCase
         $this->json('get', '/foo')
             ->assertStatus(200)
             ->assertSeeText('"baz":[]');
+    }
+
+    /** @test */
+    public function it_can_set_a_new_response_key()
+    {
+        /** @var Debugger $debugger */
+        $debugger = $this->app->make(Debugger::class);
+
+        $this->assertEquals(Debugger::DEFAULT_RESPONSE_KEY, $debugger->getResponseKey(), 'Response key is not the default');
+
+        $new_response_key = 'key123';
+
+        $debugger->setResponseKey($new_response_key);
+
+        $this->assertEquals($new_response_key, $debugger->getResponseKey(), 'Response key was not changed from "'.$debugger->getResponseKey().'" to "'.$new_response_key.'"');
     }
 }


### PR DESCRIPTION
### Features
- Add a config option to allow the developer to change the response key that the debugger uses
  - This prevents naming conflicts with other libraries that also attach to the `debug` key in responses