### PR TITLE
Add support for PHP 7.4, but drop support for below PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ dist: trusty
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ When you are developing JSON API sometimes you need to debug it, but if you will
 
 To get the latest version of Laravel Laravel-API-Debugger, simply add the following line to the require block of your `composer.json` file.
 
+For PHP >= 7.1:
+
+```
+"lanin/laravel-api-debugger": "^4.0"
+```
+
+For PHP < 7.1:
+
 ```
 "lanin/laravel-api-debugger": "^3.0"
 ```

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1",
         "illuminate/support": ">=5.4.0"
     },
     "require-dev": {
         "orchestra/testbench": ">=3.4.0",
-        "phpunit/phpunit": ">=5.7",
-        "mockery/mockery": "0.9.*"
+        "phpunit/phpunit": "^7",
+        "mockery/mockery": "^1.3.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Collections/QueriesCollection.php
+++ b/src/Collections/QueriesCollection.php
@@ -118,7 +118,7 @@ class QueriesCollection implements Collection
     {
         try {
             return (string) $attribute;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             switch (true) {
                 // Handle DateTime attribute pass.
                 case $attribute instanceof \DateTime:

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Setup the test environment.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }


### PR DESCRIPTION
Seems like in order to support PHP 7.4 (#22), there's a bit of an avalanche effect that in order to be able to run the tests in PHP 7.4, Mockery needs to be upgraded, and in turn PHPUnit needs to be updated to such a version that requires you to use `: void` return typehints in `setUp()`, thus requiring a PHP version of at least 7.1.

In this PR I've done these upgrades and also changed the README to suggest people to require a not-yet-existing `^4.0` version of this library, assuming this is a big breaking change that would require a major version bump.

This PR is meant to replace #23 as a more comprehensive one that doesn't leave the repository in an untestable state for the newest PHP version it supports.