### PR TITLE
Add on demand disabling of debugger output

### DIFF
--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -34,6 +34,11 @@ class Debugger
     protected $event;
 
     /**
+     * @var bool
+     */
+    protected $disable = false;
+
+    /**
      * Create a new Debugger service.
      *
      * @param Storage $storage
@@ -88,6 +93,16 @@ class Debugger
     }
 
     /**
+     * Disable debugger output on demand for a specific response
+     *
+     * @param bool $disable
+     */
+    public function disableOutput($disable)
+    {
+        $this->disable = $disable;
+    }
+
+    /**
      * Profile action.
      *
      * @param  string $name
@@ -137,7 +152,7 @@ class Debugger
         $isJsonResponse = $response instanceof JsonResponse ||
             $response->headers->contains('content-type', 'application/json');
 
-        return $isJsonResponse && !$this->storage->isEmpty();
+        return ! $this->disable && $isJsonResponse && !$this->storage->isEmpty();
     }
 
     /**

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -15,6 +15,19 @@ if (! function_exists('lad')) {
     }
 }
 
+if (! function_exists('lad_disable_output')) {
+    /**
+     * Disable output for a single response.
+     *
+     * @param  bool $disavle
+     * @return void
+     */
+    function lad_disable_output($disable)
+    {
+        app(Debugger::class)->disableOutput($disable);
+    }
+}
+
 if (! function_exists('lad_pr_start')) {
     /**
      * Start profiling event.

--- a/tests/DebuggerTest.php
+++ b/tests/DebuggerTest.php
@@ -245,4 +245,23 @@ class DebuggerTest extends TestCase
 
         $this->assertEquals($new_response_key, $debugger->getResponseKey(), 'Response key was not changed from "'.$debugger->getResponseKey().'" to "'.$new_response_key.'"');
     }
+
+    /** @test */
+    public function it_can_be_disabled_for_a_response()
+    {
+        $this->app['router']->get('foo', function () {
+            lad_disable_output(true);
+
+            return response()->json(['foo' => 'bar']);
+        });
+
+        $this->json('get', '/foo')
+            ->assertStatus(200)
+            ->assertJsonMissing([
+                'debug',
+            ])
+            ->assertJsonFragment([
+                'event' => 'test',
+            ]);
+    }
 }


### PR DESCRIPTION
This adds the ability to disable debugger on a per response basis, so it can be enabled for all actions, but if there's one specific action you'd like to disable it for, it can be turned off

Added a new helper `lad_disable_output(true)`