### PR TITLE
non-nullable null is deprecated

### DIFF
--- a/src/Collections/ProfilingCollection.php
+++ b/src/Collections/ProfilingCollection.php
@@ -80,9 +80,9 @@ class ProfilingCollection implements Collection
      * Start timer.
      *
      * @param string $name
-     * @param null $time
+     * @param float|null $time
      */
-    protected function start($name, $time = null)
+    protected function start(string $name, ?float $time = null)
     {
         $this->started[$name] = $time ?: microtime(true);
     }

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -49,7 +49,7 @@ if (! function_exists('lad_pr_me')) {
      * @param  Closure|null $action
      * @return mixed
      */
-    function lad_pr_me($name, \Closure $action = null)
+    function lad_pr_me($name, ?\Closure $action = null)
     {
         return app(Debugger::class)->profileMe($name, $action);
     }


### PR DESCRIPTION
https://dev.to/gromnan/fix-php-84-deprecation-implicitly-marking-parameter-as-nullable-is-deprecated-the-explicit-nullable-type-must-be-used-instead-5gp3